### PR TITLE
Add a commit message prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cz-jira-smart-commit
 
-A commitizen adapter for [Jira smart commits](https://confluence.atlassian.com/display/FISHEYE/Using+smart+commits)
+A commitizen adapter for [Jira smart commits](https://confluence.atlassian.com/display/FISHEYE/Using+smart+commits).
 
 ![Screenshot](other/screenshot.png)
 
@@ -22,14 +22,20 @@ Reference it in your `.cz.json` of your project
 }
 ```
 
+or use commitizen to init
+```
+commitizen init cz-jira-smart-commit
+```
+
 
 ### Day to day work
 
-Instead of `git commit -m 'Your message'`, you type: `git gz` with this adapter and it prompts you for:
+Instead of `git commit -m 'Your message'`, you type: `git cz` with this adapter and it prompts you for:
 
+- commit message
 - Jira Issue Key(s)
-- Time Spent
 - Workflow command
+- Time Spent
 - Comment
 
 And generates your commit based on that.

--- a/index.js
+++ b/index.js
@@ -26,6 +26,18 @@ function prompter(cz, commit) {
   cz.prompt([
     {
       type: 'input',
+      name: 'message',
+      message: 'GitHub commit message (required):\n',
+      validate: function(input) {
+        if (!input) {
+          return 'empty commit message';
+        } else {
+          return true;
+        }
+      }
+    },
+    {
+      type: 'input',
       name: 'issues',
       message: 'Jira Issue ID(s) (required):\n',
       validate: function(input) {
@@ -35,11 +47,6 @@ function prompter(cz, commit) {
           return true;
         }
       }
-    },
-    {
-      type: 'input',
-      name: 'time',
-      message: 'Time spent (i.e. 3h 15m) (optional):\n'
     },
     {
       type: 'input',
@@ -55,23 +62,23 @@ function prompter(cz, commit) {
     },
     {
       type: 'input',
-      name: 'comment',
-      message: 'Jira comment (optional):\n'
+      name: 'time',
+      message: 'Time spent (i.e. 3h 15m) (optional):\n'
     },
     {
       type: 'input',
-      name: 'message',
-      message: 'Anything else that would be helpful to note (not included in the Jira issue) (optional):\n'
-    }
+      name: 'comment',
+      message: 'Jira comment (optional):\n'
+    },
   ], commitAnswers);
 
   function commitAnswers(answers) {
     commit(filter([
+      answers.message,
       answers.issues,
-      answers.comment ? '#comment ' + answers.comment : undefined,
-      answers.time ? '#time ' + answers.time : undefined,
       answers.workflow ? '#' + answers.workflow : undefined,
-      answers.message ? '\n' + answers.message : undefined
+      answers.time ? '#time ' + answers.time : undefined,
+      answers.comment ? '#comment ' + answers.comment : undefined,
     ]).join(' '));
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -26,37 +26,37 @@ describe(`prompter`, () => {
     });
 
     it(`should call commit with the proper message`, () => {
+      const message = 'sample commit message';
       const issues = 'CZ-234 CZ-235';
-      const time = '3y 2w 7d 8h 30m';
       const workflow = 'closed';
+      const time = '3y 2w 7d 8h 30m';
       const comment = 'This took waaaaay too long';
-      const message = 'It would not have been so bad except I got distracted...';
-      commitAnswers({issues, time, workflow, comment, message});
+      commitAnswers({message, issues, workflow, time, comment});
       expect(commit).to.have.been.calledWith([
+        message,
         issues,
-        `#comment ${comment}`,
-        `#time ${time}`,
         `#${workflow}`,
-        '\n' + message
+        `#time ${time}`,
+        `#comment ${comment}`
       ].join(' '));
     });
 
-    ['comment', 'time', 'workflow', 'message'].forEach((item) => {
+    ['workflow', 'time', 'comment'].forEach((item) => {
       it(`should just leave off ${item} if it's not specified`, () => {
+        const message = 'sample commit message';
         const issues = 'CZ-234 CZ-235';
-        const time = '3y 2w 7d 8h 30m';
         const workflow = 'closed';
+        const time = '3y 2w 7d 8h 30m';
         const comment = 'This took waaaaay too long';
-        const message = 'It would not have been so bad except I got distracted...';
-        const answers = {issues, time, workflow, comment, message};
+        const answers = {message, issues, workflow, time, comment};
         delete answers[item];
         commitAnswers(answers);
         expect(commit).to.have.been.calledWith(filter([
+          message,
           issues,
-          item !== 'comment' ? `#comment ${comment}` : undefined,
-          item !== 'time' ? `#time ${time}` : undefined,
           item !== 'workflow' ? `#${workflow}` : undefined,
-          item !== 'message' ? '\n' + message : undefined
+          item !== 'time' ? `#time ${time}` : undefined,
+          item !== 'comment' ? `#comment ${comment}` : undefined
         ]).join(' '));
       });
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cz-jira-smart-commit",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "A commitizen adapter for Jira smart commits",
   "main": "index.js",
   "scripts": {
@@ -21,6 +21,9 @@
     "jira smart commit"
   ],
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
+  "contributors": [
+    "Jane Kim <jane@janekim.me> (http://janekim.me)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/commitizen/cz-jira-smart-commit/issues"


### PR DESCRIPTION
## Problem

While I was using this I realized that the commit messages generated don't have an actual commit message besides the smart hooks for JIRA. this way when you look at commits on GitHub you just see issue numbers and no message about what's actually in the commit
## Solution

This PR moves the message prompt to beginning and makes it required. That message is now used to generate the beginning of the commit message. 
## Major changes
- order of prompts
- refactor tests
