### PR TITLE
Fix for Commitzen 2.9.6 + Global Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ A commitizen adapter for [Jira smart commits](https://confluence.atlassian.com/d
 
 ## Usage
 
+### Global Installation
+
+For a quick global installation of the plugin, simply run the `install.sh` script present in this repo:
+
+```
+chmod +x install.sh
+
+./install.sh
+```
+
 ### Add this adapter
 
 Install this adapter

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function prompter(cz, commit) {
       name: 'comment',
       message: 'Jira comment (optional):\n'
     },
-  ], commitAnswers);
+  ]).then(commitAnswers);
 
   function commitAnswers(answers) {
     commit(filter([

--- a/install.sh
+++ b/install.sh
@@ -5,4 +5,3 @@ echo "Installing JIRA smart commits"
 npm install -g cz-jira-smart-commit
 echo "Creating a global config file"
 echo '{ "path": "/usr/local/lib/node_modules/cz-jira-smart-commit/" }' > ~/.czrc
-echo "You can view documentation at the link: https://fixico.atlassian.net/wiki/pages/resumedraft.action?draftId=39425512"

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 echo "Installing Commitizen Globally"
 npm install -g commitizen
 echo "Installing JIRA smart commits"
-npm install -g https://github.com/pgoodjohn/cz-jira-smart-commit
+npm install -g cz-jira-smart-commit
 echo "Creating a global config file"
 echo '{ "path": "/usr/local/lib/node_modules/cz-jira-smart-commit/" }' > ~/.czrc
 echo "You can view documentation at the link: https://fixico.atlassian.net/wiki/pages/resumedraft.action?draftId=39425512"

--- a/install.sh
+++ b/install.sh
@@ -5,4 +5,4 @@ echo "Installing JIRA smart commits"
 npm install -g https://github.com/pgoodjohn/cz-jira-smart-commit
 echo "Creating a global config file"
 echo '{ "path": "/usr/local/lib/node_modules/cz-jira-smart-commit/" }' > ~/.czrc
-echo "You can view documentation at the link: "
+echo "You can view documentation at the link: https://fixico.atlassian.net/wiki/pages/resumedraft.action?draftId=39425512"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+echo "Installing Commitizen Globally"
+npm install -g commitizen
+echo "Installing JIRA smart commits"
+npm install -g https://github.com/pgoodjohn/cz-jira-smart-commit
+echo "Creating a global config file"
+echo '{ "path": "/usr/local/lib/node_modules/cz-jira-smart-commit/" }' > ~/.czrc
+echo "You can view documentation at the link: "


### PR DESCRIPTION
Edited `index.js` to work with Commitzen 2.9.6.

Also added a `.sh` script to install `cz-jira-smart-commit` globally and set it as default Commitzen configuration.